### PR TITLE
Importファイルのの再帰作成機能の作成

### DIFF
--- a/module-packing.scm
+++ b/module-packing.scm
@@ -85,18 +85,18 @@
 )
 
 ; (require ...) (import ...)を書き込む
-(define (write-require-and-import-sexpr-to-pack-file modules pack-name out-port)
+; [TODO] names引数の部分がきれいじゃないから直す
+(define (write-require-and-import-sexpr-to-pack-file modules names pack-name out-port)
     (cond
         ((null? modules))
         (else
             ; S式で再帰しながら書いたほうがきれいだよね...
             ; require
-            ; [TODO] 入れ子のモジュールのパス名を記載する方法を考える。 → module-listだけでなく、module-path-listも必要であることに気づいた。
             (display (string-append "(require \""  (x->string (car modules)) "\")") out-port)
             ; import
-            (display (string-append "(import " (x->string (car modules)) ")") out-port)
+            (display (string-append "(import " (x->string (car names)) ")") out-port)
             (newline out-port)
-            (write-require-and-import-sexpr-to-pack-file (cdr modules) pack-name out-port)
+            (write-require-and-import-sexpr-to-pack-file (cdr modules) (cdr names) pack-name out-port)
         )
     )
 )
@@ -181,7 +181,7 @@
                 (display (list (string-append "select-module " pack-name)) out)
                 (newline out)
 
-                (write-require-and-import-sexpr-to-pack-file module-list pack-name out)
+                (write-require-and-import-sexpr-to-pack-file module-list (build-modules module-list) pack-name out)
                 (display (string-append "(provide \"" pack-name "\")") out)
 
                 (close-output-port out)

--- a/module-packing.scm
+++ b/module-packing.scm
@@ -156,16 +156,12 @@
             (exit 0)
         )
 
-        (let 
+        (let* 
             (
                 (pack-name ((lambda (m r) (if (pair? restargs) (car r) m)) modules-name restargs))
+                (module-list (directory-list (build-path "./" pack-name) :add-path? #t :children? #t))
+                (out (open-output-file (build-path (current-directory) (string-append pack-name ".scm"))))
             )
-            (let
-                (
-                    (module-list (directory-list (build-path "./" pack-name) :add-path? #t :children? #t))
-                    (out (open-output-file (build-path (current-directory) (string-append pack-name ".scm")))) 
-                )
-
                 ; recurコマンドライン引数を設定しなかった場合、サブディレクトリはmodule-list内から削除
                 (cond 
                     ((eq? is-recur #f) (set! module-list (remove file-is-directory? module-list)))
@@ -185,7 +181,6 @@
                 (display (string-append "(provide \"" pack-name "\")") out)
 
                 (close-output-port out)
-            )
         )
     )
 )

--- a/module-packing.scm
+++ b/module-packing.scm
@@ -91,7 +91,8 @@
         (else
             ; S式で再帰しながら書いたほうがきれいだよね...
             ; require
-            (display (string-append "(require \"./" pack-name "/" (x->string (car modules)) "\")") out-port)
+            ; [TODO] 入れ子のモジュールのパス名を記載する方法を考える。 → module-listだけでなく、module-path-listも必要であることに気づいた。
+            (display (string-append "(require \"./" pack-name "/" (x->string #?=(car modules)) "\")") out-port)
             ; import
             (display (string-append "(import " (x->string (car modules)) ")") out-port)
             (newline out-port)

--- a/module-packing.scm
+++ b/module-packing.scm
@@ -129,7 +129,7 @@
         (
             (outfile-name "o|outfile=s")
             (modules-name "m|module=s")
-            (is-recur "r|recure")
+            (is-recur "r|recur")
             . restargs
         )
         
@@ -146,6 +146,11 @@
                 (
                     (module-list (directory-list (build-path (current-directory) pack-name) :add-path? #t :children? #t))
                     (out (open-output-file (build-path (current-directory) (string-append pack-name ".scm")))) 
+                )
+
+                ; recurコマンドライン引数を設定しなかった場合、サブディレクトリはmodule-list内から削除
+                (if (eq? is-recur #f)
+                    (set! module-list (remove file-is-directory? module-list))
                 )
 
                 (display (cons (string-append "define-module " pack-name) (build-exports module-list)) out)

--- a/module-packing.scm
+++ b/module-packing.scm
@@ -1,3 +1,4 @@
+(use srfi-13)
 (use file.util)
 (use gauche.parseopt)
 
@@ -92,12 +93,21 @@
         (else
             ; S式で再帰しながら書いたほうがきれいだよね...
             ; require
-            (display (string-append "(require \""  (x->string (car modules)) "\")") out-port)
+            (display (string-append "(require \"" (x->string (car modules)) "\")") out-port)
             ; import
             (display (string-append "(import " (x->string (car names)) ")") out-port)
             (newline out-port)
             (write-require-and-import-sexpr-to-pack-file (cdr modules) (cdr names) pack-name out-port)
         )
+    )
+)
+
+(define (replace-yen-to-slash modules)
+    (cond
+        ((null? modules) '())
+        (else
+            (cons (string-join (string-split (car modules) "\\") "/") (replace-yen-to-slash (cdr modules)))
+        )    
     )
 )
 
@@ -170,6 +180,9 @@
                         (set! module-list (find-module-recur module-list pack-name))
                     )
                 )
+
+                ; \を/に変換
+                (set! module-list (replace-yen-to-slash module-list))
 
                 (display (cons (string-append "define-module " pack-name) (build-exports module-list)) out)
                 (newline out)

--- a/module-packing.scm
+++ b/module-packing.scm
@@ -124,6 +124,23 @@
     )
 )
 
+; サブディレクトリを再帰的に検索する。
+(define (find-module-recur module-list pack-name)
+    (define (_find-module-recur module-list result pack-name)
+        (cond
+            ((null? module-list) result)
+            ; ディレクトリならば再帰的に中のファイルを取得する
+            ((file-is-directory? (car module-list))
+                (_find-module-recur (directory-list (car module-list) :add-path? #t :children? #t) result pack-name)
+            )
+            (else
+                (_find-module-recur (cdr module-list) (cons (car module-list) result) pack-name)
+            )
+        )
+    )
+    (_find-module-recur module-list '() pack-name)
+)
+
 (define (main args)
     (let-args (cdr args)
         (
@@ -151,6 +168,7 @@
                 ; recurコマンドライン引数を設定しなかった場合、サブディレクトリはmodule-list内から削除
                 (if (eq? is-recur #f)
                     (set! module-list (remove file-is-directory? module-list))
+                    (set! module-list (find-module-recur module-list pack-name))
                 )
 
                 (display (cons (string-append "define-module " pack-name) (build-exports module-list)) out)


### PR DESCRIPTION
- [x] 【Fixing】recurコマンドライン引数が#fの時の処理をmain手続き内に追加。
- [x] 【Working】recurコマンドライン引数が#tの時のサブディレクトリ内のmoduleファイルを再帰的に取得する処理を記述。 ※ write-require-and-import-sexpr-to-pack-file手続き内でrequireの記述部分が未完成。
- [x] 【Working】修正の方針が決まったので、コード中に方針をコメントとして残しておいた。
- [x] 【Working】requireの文面を書き出す部分を修正した。 ※ importの文面を書き出す部分がまだ。
- [x] 【Working】 importの文面を書き出す部分を修正した。
- [x] 【Fixing】 main-srgs手続きの中のletをlet*に変更した。
- [x] 【Fixing】 require手続き内でのディレクトリのパーティションを\から/に変換する手続きを追加。
